### PR TITLE
Mise à jour du README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ L'équipe du Point d'Accès National aux données de transport (transport.data.g
 
 # Contributions
 
-Toute personne souhaitant contribuer aux travaux peuvent se rapprocher de l'animatrice du GT7 (@TuThoThai).
+Toute personne souhaitant contribuer aux travaux peut se rapprocher de l'animatrice du GT7 (@TuThoThai).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
-## MIGRATION EN COURS
+# Profil France de SIRI
 
-:warning: ce repository est à l'origine une copie conforme de https://github.com/etalab/transport-normes au commit 536ce0493ccc3fdf1c4d0be81950b2f70bcbf554.
+Ce répertoire regroupe l'ensemble des éléments du profil France de SIRI tel que publié sur le site : https://normes.transport.data.gouv.fr.
 
-Voir:
-- https://github.com/etalab/transport-normes/issues
-- https://github.com/etalab/transport-normes/issues/65
+# Structure
 
+Ce répertoire est composé :
+- d'un dossier `SIRI` qui comprend le profil France au format Markdown
+- d'un dossier `originaux` qui comprend le dernier document du profil publié par le GT7 après appobation du CN03.
+
+# Gouvernance
+
+Le contenu de ce répertoire le travail de normalisation au sein du GT7 (groupe de travail dédié à l'information voyageur et l'exploitation des services de mobilité). Ce groupe de travail s'insère dans les travaux de la CN03 (Commission nationale pour les transports publics) au sein du BNTRA (Bureau de normalisation pour les transports, les routes et leurs aménagements).
+Toute personne peut poser des questions, faire des demandes de changement du profil France de SIRI en utilisant les `Issues` de ce répetoire. Si les discussions peuvent avoir lieu directement ici, les décisions finales seront prises par les membres du GT7 lors des plénières. Ces décisions sont, ensuite, avalisées formellement par la CN03 lors de ses plénières.
+
+L'équipe du Point d'Accès National aux données de transport (transport.data.gouv.fr) soutient le maintien technique de ce répertoire. Elle n'est pas responsable du contenu.
+
+# Contributions
+
+Toute personne souhaitant contribuer aux travaux peuvent se rapprocher de l'animatrice du GT7 (@TuThoThai).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ce répertoire est composé :
 
 # Gouvernance
 
-Le contenu de ce répertoire le travail de normalisation au sein du GT7 (groupe de travail dédié à l'information voyageur et l'exploitation des services de mobilité). Ce groupe de travail s'insère dans les travaux de la CN03 (Commission nationale pour les transports publics) au sein du BNTRA (Bureau de normalisation pour les transports, les routes et leurs aménagements).
+Le contenu de ce répertoire est le travail de normalisation au sein du GT7 (groupe de travail dédié à l'information voyageur et l'exploitation des services de mobilité). Ce groupe de travail s'insère dans les travaux de la CN03 (Commission nationale pour les transports publics) au sein du BNTRA (Bureau de normalisation pour les transports, les routes et leurs aménagements).
 Toute personne peut poser des questions, faire des demandes de changement du profil France de SIRI en utilisant les `Issues` de ce répetoire. Si les discussions peuvent avoir lieu directement ici, les décisions finales seront prises par les membres du GT7 lors des plénières. Ces décisions sont, ensuite, avalisées formellement par la CN03 lors de ses plénières.
 
 L'équipe du Point d'Accès National aux données de transport (transport.data.gouv.fr) soutient le maintien technique de ce répertoire. Elle n'est pas responsable du contenu.


### PR DESCRIPTION
Je propose de bien démarrer 2025 en mettant enfin à jour le `readme.md` du profil France de SIRI. Pour le moment, je souhaite faire light et on pourra améliorer avec les numéros de version, change log et exemples plus tard.