### PR TITLE
Service Discovery/Réponse au FacilityRequest

### DIFF
--- a/SIRI/profil-france/index.md
+++ b/SIRI/profil-france/index.md
@@ -9885,6 +9885,13 @@ AffectedVehicleJourney</p>
 <td>Gravité de la SITUATION. La valeur par défaut est normale (<mark>cf
 6.7.4.1.4).</mark></td>
 </tr>
+<tr>
+<td>Affects</td>
+<td><em><strong><mark>Affects</mark></strong></em></td>
+<td>0:1</td>
+<td><em>AffectsScope</em></td>
+<td>Modèle structuré identifiant les parties de l'offre affetées par la conséquence. Voir 6.7.4.1.7.6.</td>  
+</tr>
 <tr class="odd">
 <td><em>Advice</em></td>
 <td><em><strong><mark>Advice</mark></strong></em></td>

--- a/SIRI/profil-france/index.md
+++ b/SIRI/profil-france/index.md
@@ -9890,7 +9890,7 @@ AffectedVehicleJourney</p>
 <td><em><strong><mark>Affects</mark></strong></em></td>
 <td>0:1</td>
 <td><em>AffectsScope</em></td>
-<td>Modèle structuré identifiant les parties de l'offre affetées par la conséquence. Voir 6.7.4.1.7.6.</td>  
+<td>Modèle structuré identifiant les parties de l'offre affectées par la conséquence. Voir 6.7.4.1.7.6.</td>  
 </tr>
 <tr class="odd">
 <td><em>Advice</em></td>

--- a/SIRI/profil-france/index.md
+++ b/SIRI/profil-france/index.md
@@ -1,6 +1,6 @@
 ---
-title: "SIRI - Profil France v1.7"
-date: 2023-07-27T00:00:00+00:00
+title: "SIRI - Profil France v1.8"
+date: 2025-xx-xxT00:00:00+00:00
 draft: false
 tags: ["SIRI"]
 autonumbering: true
@@ -9,9 +9,9 @@ autonumbering: true
 Profil d'échange pour la description des informations temps-réel des
 réseaux de transport en commun
 
-**SIRI - Profil Français v1.7**
+**SIRI - Profil Français v1.8**
 
-**BNTRA-CN03-GT7_NF Profil SIRI FR_v1.7 20230727**
+**BNTRA-CN03-GT7_NF Profil SIRI FR_v1.8 2025MMDD**
 
 **Avant-propos**
 
@@ -9543,7 +9543,7 @@ l'utilisation du texte par défaut.</td>
 <tr class="odd">
 <td></td>
 <td><em><strong><mark>Affects</mark></strong></em></td>
-<td>0:1</td>
+<td><mark>1:1</mark></td>
 <td><em>+Structure</em></td>
 <td><p>Identification des parties du réseau de transport affectées par
 la SITUATION.</p>


### PR DESCRIPTION

Le chapitre de description de la réponse au requete Discovery InfoChannel est corriger le Texte actuel est à remplacer par :
Dans le cadre du profil France :
	le champ facultatif « Monitored » sera toujours présent et égal à « true » (inutile de traiter les équipements pour lesquels on n’a pas d'information temps réel ou au moins mis à jour quotidiennement. 
	Le  champ facultatif «Facility» sera toujours présent :
o	Le champ facultatif «FacilityRef» ne sera jamais présent (déjà disponible au niveau supérieur),
o	Le champ facultatif «Description» reste facultatif,
o	Le champ facultatif «FacilityClass» reste facultatif,
o	Le champ facultatif «Feature» sera toujours présent et instancié,
o	Le champ facultatif «FacilityLocation» sera toujours présent et instancié,
o	Le champ AccessibilityAssessment reste facultatif,
	Le champ facultatif «Extension» ne sera jamais présent.

Se reporter au profil NeTEx France Netex pour l’interprétation des différents champs contenus dans AccessibilityAssessment, suitability,user need
En effet la phrase "Les champs facultatifs «SuitableFor» et «NotSuitableFor» restent facultatifs," n'est plus conforme à la xsd et à la défintion SIRI.

